### PR TITLE
ci(release): Adiciona workflow unificado para release com Release Draft

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -2,16 +2,13 @@
 name: 🔖 Releaser
 
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - main
+  push:
     tags:
       - 'v*'
-
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
 
 concurrency:
   cancel-in-progress: true
@@ -20,8 +17,11 @@ concurrency:
 jobs:
   draft:
     name: Create Release Draft
-    if: github.ref_name == 'main'
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Update Release Draft
         uses: release-drafter/release-drafter@v6
@@ -32,6 +32,8 @@ jobs:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Este commit introduz uma nova pipeline de release automatizada utilizando
o GitHub Actions, com o objetivo de separar a preparação das notas de
release da sua publicação final.

- Adiciona a configuração do `release-drafter` em `.github/release-drafter.yml`
  para categorizar automaticamente os Pull Requests em um rascunho de release.

- Cria um único workflow em `.github/workflows/release.yaml` que lida
  com dois cenários, usando condicionais `if`:
  1. Em eventos de `pull_request` para a branch `main`, o job `draft` é
     executado para manter o rascunho da release atualizado.
  2. Em pushes de `tags` (ex: `v0.2.0`), o job `release` é executado,
     usando o `GoReleaser` para construir os binários e publicá-los
     na release que foi criada a partir do rascunho.

Esta abordagem torna o processo de release mais robusto, colaborativo
e menos propenso a erros manuais