### PR TITLE
fix(ci): Corrige os nomes das labels no release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,17 +4,17 @@ tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 Features'
     labels:
-      - 'feature'
-      - 'enhancement'
+      - '🚀 feature'
+      - '✨ enhancement'
   - title: '🐛 Bug Fixes'
     labels:
-      - 'fix'
-      - 'bug'
+      - '🐛 bug'
+      - '🩹 fix'
   - title: '🧹 Maintenance'
     labels:
-      - 'chore'
-      - 'docs'
-      - 'ci'
+      - '🧹 chore'
+      - '📚 docs'
+      - '🤖 ci'
 template: |
   ## What's Changed
 


### PR DESCRIPTION
Atualiza as labels no arquivo de configuração .github/release-drafter.yml
para que incluam os emojis, correspondendo exatamente às labels
reais no repositório. Isto corrige o bug que impedia a
categorização automática dos PRs nas notas de release.